### PR TITLE
Adding tools missing from immport-tools.yaml file

### DIFF
--- a/immport-tools.yaml
+++ b/immport-tools.yaml
@@ -79,3 +79,6 @@ tools:
   - name: txt_diagnosis
     owner: immport-devteam
     tool_panel_section_id: flowfiletools
+  - name: upload_files
+    owner: immport-devteam
+    tool_panel_section_id: fcsfiletools

--- a/immport-tools.yaml
+++ b/immport-tools.yaml
@@ -41,7 +41,7 @@ tools:
     owner: immport-devteam
     tool_panel_section_id: fcsfiletools
   - name: fcs_merge_downsample
-    owner: immport-devteam
+    owner: azomics
     tool_panel_section_id: fcsfiletools
   - name: fcs_scatterplot
     owner: immport-devteam
@@ -65,13 +65,13 @@ tools:
     owner: immport-devteam
     tool_panel_section_id: flowvisualizationtools
   - name: flowsom_compare
-    owner: immport-devteam
+    owner: azomics
     tool_panel_section_id: flowanalysistools
   - name: flowsom_cross_comp
-    owner: immport-devteam
+    owner: azomics
     tool_panel_section_id: flowanalysistools
   - name: flowsom_tree
-    owner: immport-devteam
+    owner: azomics
     tool_panel_section_id: flowanalysistools
   - name: flowtext_scatterplot
     owner: immport-devteam
@@ -80,13 +80,13 @@ tools:
     owner: immport-devteam
     tool_panel_section_id: flowfiletools
   - name: flowviz_density_plots
-    owner: immport-devteam
+    owner: azomics
     tool_panel_section_id: flowvisualizationtools
   - name: generate_mfi
     owner: immport-devteam
     tool_panel_section_id: flowanalysistools
   - name: ggcyto_1d_density_plots
-    owner: immport-devteam
+    owner: azomics
     tool_panel_section_id: flowvisualizationtools
   - name: merge_ds_flowtext
     owner: immport-devteam

--- a/immport-tools.yaml
+++ b/immport-tools.yaml
@@ -103,7 +103,5 @@ tools:
   - name: txt_diagnosis
     owner: immport-devteam
     tool_panel_section_id: flowfiletools
-  - name: upload_files
-    owner: immport-devteam
-    tool_panel_section_id: fcsfiletools
+
 

--- a/immport-tools.yaml
+++ b/immport-tools.yaml
@@ -13,6 +13,9 @@ tools:
   - name: check_headers
     owner: immport-devteam
     tool_panel_section_id: flowfiletools
+  - name: clustergrammer_flow
+    owner: immport-devteam
+    tool_panel_section_id: flowfiletools
   - name: collapse_pop
     owner: immport-devteam
     tool_panel_section_id: flowfiletools
@@ -25,6 +28,9 @@ tools:
   - name: cs_overview
     owner: immport-devteam
     tool_panel_section_id: flowvisualizationtools
+  - name: edit_fcs_markers
+    owner: immport-devteam
+    tool_panel_section_id: flowfiletools
   - name: extract_fcs_keywords
     owner: immport-devteam
     tool_panel_section_id: fcsfiletools
@@ -32,6 +38,9 @@ tools:
     owner: immport-devteam
     tool_panel_section_id: flowfiletools
   - name: fcs_gate_trans
+    owner: immport-devteam
+    tool_panel_section_id: fcsfiletools
+  - name: fcs_merge_downsample
     owner: immport-devteam
     tool_panel_section_id: fcsfiletools
   - name: fcs_scatterplot
@@ -55,15 +64,30 @@ tools:
   - name: flow_overview
     owner: immport-devteam
     tool_panel_section_id: flowvisualizationtools
+  - name: flowsom_compare
+    owner: immport-devteam
+    tool_panel_section_id: flowanalysistools
+  - name: flowsom_cross_comp
+    owner: immport-devteam
+    tool_panel_section_id: flowanalysistools
+  - name: flowsom_tree
+    owner: immport-devteam
+    tool_panel_section_id: flowanalysistools
   - name: flowtext_scatterplot
     owner: immport-devteam
     tool_panel_section_id: flowfiletools
   - name: flowtext_summary
     owner: immport-devteam
     tool_panel_section_id: flowfiletools
+  - name: flowviz_density_plots
+    owner: immport-devteam
+    tool_panel_section_id: flowvisualizationtools
   - name: generate_mfi
     owner: immport-devteam
     tool_panel_section_id: flowanalysistools
+  - name: ggcyto_1d_density_plots
+    owner: immport-devteam
+    tool_panel_section_id: flowvisualizationtools
   - name: merge_ds_flowtext
     owner: immport-devteam
     tool_panel_section_id: flowfiletools
@@ -82,6 +106,4 @@ tools:
   - name: upload_files
     owner: immport-devteam
     tool_panel_section_id: fcsfiletools
-  - name: edit_fcs_markers
-    owner: immport-devteam
-    tool_panel_section_id: flowfiletools
+

--- a/immport-tools.yaml
+++ b/immport-tools.yaml
@@ -82,3 +82,6 @@ tools:
   - name: upload_files
     owner: immport-devteam
     tool_panel_section_id: fcsfiletools
+  - name: edit_fcs_markers
+    owner: immport-devteam
+    tool_panel_section_id: flowfiletools

--- a/immport-tools.yaml
+++ b/immport-tools.yaml
@@ -13,9 +13,6 @@ tools:
   - name: check_headers
     owner: immport-devteam
     tool_panel_section_id: flowfiletools
-  - name: clustergrammer_flow
-    owner: immport-devteam
-    tool_panel_section_id: flowfiletools
   - name: collapse_pop
     owner: immport-devteam
     tool_panel_section_id: flowfiletools
@@ -103,4 +100,3 @@ tools:
   - name: txt_diagnosis
     owner: immport-devteam
     tool_panel_section_id: flowfiletools
-

--- a/immport-tools.yaml
+++ b/immport-tools.yaml
@@ -29,7 +29,7 @@ tools:
     owner: immport-devteam
     tool_panel_section_id: flowvisualizationtools
   - name: edit_fcs_markers
-    owner: immport-devteam
+    owner: azomics
     tool_panel_section_id: flowfiletools
   - name: extract_fcs_keywords
     owner: immport-devteam
@@ -103,5 +103,4 @@ tools:
   - name: txt_diagnosis
     owner: immport-devteam
     tool_panel_section_id: flowfiletools
-
 


### PR DESCRIPTION
Added the following tools, which were in the immport-galaxy-tools/flowtools repository but not the immport-tools.yaml file:

fcs_merge_downsample
flowsom_compare
flowsom_cross_comp
flowsom_tree
flowviz_density_plots
ggcyto_1d_density_plots

I also moved the edit_fcs_markers tool